### PR TITLE
Remove reference to deprecated `adsrc` column

### DIFF
--- a/lib/upsert/column_definition/postgresql.rb
+++ b/lib/upsert/column_definition/postgresql.rb
@@ -6,7 +6,7 @@ class Upsert
         # activerecord-3.2.5/lib/active_record/connection_adapters/postgresql_adapter.rb#column_definitions
         def all(connection, quoted_table_name)
           res = connection.execute <<-EOS
-  SELECT a.attname AS name, format_type(a.atttypid, a.atttypmod) AS sql_type, d.adsrc AS default
+  SELECT a.attname AS name, format_type(a.atttypid, a.atttypmod) AS sql_type, pg_get_expr(adbin, adrelid) AS default
   FROM pg_attribute a LEFT JOIN pg_attrdef d
   ON a.attrelid = d.adrelid AND a.attnum = d.adnum
   WHERE a.attrelid = '#{quoted_table_name}'::regclass


### PR DESCRIPTION
This came up while testing Postgresql 12. This column had a
deprecation notice since v8.0 (https://www.postgresql.org/docs/8.0/catalog-pg-attrdef.html).